### PR TITLE
Wrong From fied's value in a calendar reminder email notification aft…

### DIFF
--- a/calendar-service/src/main/java/org/exoplatform/calendar/service/ReminderJob.java
+++ b/calendar-service/src/main/java/org/exoplatform/calendar/service/ReminderJob.java
@@ -139,7 +139,7 @@ public class ReminderJob extends MultiTenancyJob {
               } else {
                 message.setBody("");
               }
-              message.setFrom(jdatamap.getString("account"));
+              message.setFrom(System.getProperty("exo.email.smtp.from"));
               if (isRepeat) {
                 if (fromCalendar.getTimeInMillis() >= fromTime) {
                   reminder.setProperty(Utils.EXO_IS_OVER, true);


### PR DESCRIPTION
The "account" property is not set anywhere so  jdatamap.getString("account") will return always null and the "from" field will be set to the local address from the standard java mail InternetAddress.getLocalAddress(session)