### PR TITLE
CAL-1301 : use .val(val) instead of .attr('value', val) to set correctly the input value

### DIFF
--- a/calendar-webapp/src/main/webapp/javascript/eXo/calendar/ScheduleSupport.js
+++ b/calendar-webapp/src/main/webapp/javascript/eXo/calendar/ScheduleSupport.js
@@ -107,16 +107,16 @@ var ScheduleSupport = {
 		       hiddenInput0 = gj(detailsCombos[0]).prevAll('input')[0];
 		       hiddenInput1 = gj(detailsCombos[1]).prevAll('input')[0];
 		       if(hiddenInput0.name.toLowerCase().indexOf('from') > -1) {
-		           gj(detailsCombos[0]).attr("value",start);
-		           gj(hiddenInput0).attr("value",start);
-		           gj(detailsCombos[1]).attr("value",end);
-		           gj(hiddenInput1).attr("value",end);
+		           gj(detailsCombos[0]).val(start);
+		           gj(hiddenInput0).val(start);
+		           gj(detailsCombos[1]).val(end);
+		           gj(hiddenInput1).val(end);
 
 		       } else {
-		           gj(detailsCombos[1]).attr("value",start);
-		           gj(hiddenInput1).attr("value",start);
-		           gj(detailsCombos[0]).attr("value",end);
-		           gj(hiddenInput0).attr("value",start);
+		           gj(detailsCombos[1]).val(start);
+		           gj(hiddenInput1).val(start);
+		           gj(detailsCombos[0]).val(end);
+		           gj(hiddenInput0).val(start);
 		       }
 		   }
 		   // sync detail tab to schedule tab
@@ -133,16 +133,16 @@ var ScheduleSupport = {
 		       hiddenInput0 = gj(scheduleCombos[0]).prevAll('input')[0];
 		       hiddenInput1 = gj(scheduleCombos[1]).prevAll('input')[0];
 		       if(hiddenInput0.name.toLowerCase().indexOf('from') > -1) {
-		           gj(scheduleCombos[0]).attr("value",start);
-		           gj(hiddenInput0).attr("value",start);
-		           gj(scheduleCombos[1]).attr("value",end);
-		           gj(hiddenInput1).attr("value",end);
+		           gj(scheduleCombos[0]).val(start);
+		           gj(hiddenInput0).val(start);
+		           gj(scheduleCombos[1]).val(end);
+		           gj(hiddenInput1).val(end);
 
 		       } else {
-		           gj(scheduleCombos[1]).attr("value",start);
-		           gj(hiddenInput1).attr("value",start);
-		           gj(scheduleCombos[0]).attr("value",end);
-		           gj(hiddenInput0).attr("value",start);
+		           gj(scheduleCombos[1]).val(start);
+		           gj(hiddenInput1).val(start);
+		           gj(scheduleCombos[0]).val(end);
+		           gj(hiddenInput0).val(start);
 		       }
 		   }
 		}

--- a/calendar-webapp/src/main/webapp/javascript/eXo/calendar/UICombobox.js
+++ b/calendar-webapp/src/main/webapp/javascript/eXo/calendar/UICombobox.js
@@ -57,7 +57,7 @@
       }
       
       var item = jInput.parent().find('.UIComboboxLabel').get(idx);
-      jInput.attr('value', gj(item).html());
+      jInput.val(gj(item).html());
       wx.UICombobox.setSelectedItem(jInput.get(0));
     } else {
       wx.UICombobox.complete(this, e);
@@ -91,9 +91,9 @@
     var UICombobox = eXo.webui.UICombobox;
     var val = obj.getAttribute("value");
     var hiddenField = gj(UICombobox.list.parentNode).next("input");
-    hiddenField.attr("value", val);
+    hiddenField.val(val);
     var text = hiddenField.next("input");
-    text.attr("value", gj(obj).find(".UIComboboxLabel").first().html());
+    text.val(gj(obj).find(".UIComboboxLabel").first().html());
     ScheduleSupport.syncTimeBetweenEventTabs();
     
     ScheduleSupport.applyPeriod();


### PR DESCRIPTION
The time input were updated with jquery method attr(). It updated the dom input value but did not update correctly the rendering. Using val() method instead resolves this issue.