### PR TITLE
CAL-1308 : clone EventQuery before modifying when fetching events to avoid side effects in subsequent queries

### DIFF
--- a/calendar-service/src/main/java/org/exoplatform/calendar/model/query/EventQuery.java
+++ b/calendar-service/src/main/java/org/exoplatform/calendar/model/query/EventQuery.java
@@ -24,7 +24,7 @@ import org.exoplatform.calendar.service.Utils;
  * @author <a href="trongtt@exoplatform.com">Trong Tran</a>
  * @version $Revision$
  */
-public class EventQuery implements Query {
+public class EventQuery implements Query, Cloneable {
 
   private String ds;
   
@@ -175,5 +175,10 @@ public class EventQuery implements Query {
 
   public void setDS(String id) {
     this.ds = id;
+  }
+
+  @Override
+  public Object clone() throws CloneNotSupportedException {
+    return super.clone();
   }
 }


### PR DESCRIPTION
The object EventQuery is modified in the method EventHandlerImpl.findEventsByQuery which causes a side effect in subsequent calls to this method (the datasource is not null anymore so the events are fetched from all datasources anymore).
This PR clones the EventQuery object when we need to modify it (immutability FTW!).