### PR TITLE
CAL-1284 : sort correctly events by start date in monthly view

### DIFF
--- a/calendar-webapp/src/main/webapp/javascript/eXo/calendar/EventObject.js
+++ b/calendar-webapp/src/main/webapp/javascript/eXo/calendar/EventObject.js
@@ -38,20 +38,14 @@ EventObject.prototype.init = function(rootNode) {
   this.eventIndex = this.rootNode.getAttribute('eventindex');
   this.calId = this.rootNode.getAttribute('calid');
   this.eventCat = this.rootNode.getAttribute('eventcat');
-  this.startTime = this.normalizeDate(this.rootNode.getAttribute('starttimefull'));//Date.parse(this.rootNode.getAttribute('starttimefull'));
-  this.endTime = Date.parse(this.rootNode.getAttribute('endtimefull'));
+  this.startTime = this.rootNode.getAttribute('starttime');
+  this.endTime = this.rootNode.getAttribute('endtime');
 
   if (this.rootNode.innerText) {
     this.name = gj.trim(this.rootNode.innerText + '');
   } else {
     this.name = gj.trim(this.rootNode.textContent + '');
   }
-};
-
-EventObject.prototype.normalizeDate = function(dateStr) {
-	var d = new Date(dateStr);
-	if(document.getElementById("UIWeekView")) return Date.parse(dateStr);
-	return (new Date(d.getFullYear(),d.getMonth(),d.getDate(),0,0,0,0)).getTime();
 };
 
 EventObject.prototype.updateIndicator = function(nodeObj, hasBefore, hasAfter) {


### PR DESCRIPTION
The events are already well sorted by start date but when creating EventObjects, only the date/month/year information are kept and used to do the sorting, we lose the real start time (hours/minutes/...).
This PR keeps the real time in EventObject objects to allow to do the right sorting.