### PR TITLE
CAL-1320 : manage correctly checkbox visibility state of Task calendars

### DIFF
--- a/calendar-webapp/src/main/java/org/exoplatform/calendar/webui/UICalendars.java
+++ b/calendar-webapp/src/main/java/org/exoplatform/calendar/webui/UICalendars.java
@@ -16,13 +16,7 @@
  **/
 package org.exoplatform.calendar.webui;
 
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.ResourceBundle;
-import java.util.Set;
+import java.util.*;
 
 import javax.jcr.PathNotFoundException;
 
@@ -123,11 +117,12 @@ public class UICalendars extends UIForm  {
   }
 
   public void init() throws Exception {
-    String invisibleCalendars = "";
+    List<String> invisibleCalendars = new ArrayList<>();
     SettingService settingService = getApplicationComponent(SettingService.class);
     SettingValue<?> value = settingService.get(Context.USER, Scope.APPLICATION.id(UICalendarPortlet.CALENDAR_APP_SETTING_SCOPE), UICalendarPortlet.CALENDAR_INVISIBLE_SETTING_KEY);
     if (value != null) {
-      invisibleCalendars = (String) value.getValue();
+      String invisibleCalendarsValue = (String) value.getValue();
+      invisibleCalendars = Arrays.asList(invisibleCalendarsValue.split(","));
     }
 
     Map<String, List<Calendar>> tmp = getCalendars();

--- a/calendar-webapp/src/main/webapp/templates/calendar/webui/UICalendars.gtmpl
+++ b/calendar-webapp/src/main/webapp/templates/calendar/webui/UICalendars.gtmpl
@@ -209,6 +209,9 @@
     def others = uicomponent.getAllOtherCalendars();
     if (others == null || others.size() == 0) return;
     def otherTitle = _ctx.appRes("UICalendars.label.other");
+
+    UICalendarPortlet uiCalendarPortlet = uicomponent.getAncestorOfType(UICalendarPortlet.class);
+    def isInSpaceContext = uiCalendarPortlet.isInSpaceContext();
     %>
 	  <div class="myCalendar">
 	    <h6 class="calendarTitle">$otherTitle</h6>
@@ -231,6 +234,8 @@
 		        def calendarType = calendar.getCalType();
 
 		        if (calendar.getViewPermission()!= null && calendar.getViewPermission().length > 0) icon = "SharedCalendarIcon";
+
+		        if (!chk.isChecked() || (isInSpaceContext && !uicomponent.isCalendarOfSpace(calendar))) css = "iconUnCheckBox checkbox";
 		    %>
 		        <li class="calendarItem  CalendarItemPrivate" calColor="$color" canEdit="<%=isEditable%>" id="$compositeID" calType="<%=calendarType%>" isRemote="$isRemote">
 		        <div id="UICalendars_CalendarPopupMenu1" class="uiIconCalSettingMini uiIconLightGray pull-right"></div>


### PR DESCRIPTION
The visibility status of the calendars listed in the Project section in the Calendar application were not done. The status of the checkbox was always set as checked.
This fix manages this status correctly by checking the real state of the checkbox in order to add the right CSS class (as for others calendars types).
It also fixes the comparaison between the list of invisible calendars (stored in the settings as a comma-separated list of calendars ids) with the calendars ids. The previous comparaison was based on a basic string comparaison which led to bad results. The new comparaison is based on a list of compare exactly the ids.