### PR TITLE
CAL-1468 : 'Display a notification pop-up' in other language version

### DIFF
--- a/calendar-webapp/src/main/webapp/vue-app/components/ExoCalendarReminderForm.vue
+++ b/calendar-webapp/src/main/webapp/vue-app/components/ExoCalendarReminderForm.vue
@@ -22,7 +22,7 @@
       <div class="reminderByPopup">
         <div id="popupReminder" class="popupReminder">
           <label class="uiCheckbox">
-            <input id="popupReminder" v-model="popupReminder" type="checkbox" class="checkbox" name="popupReminder"><span>Display a notification pop-up</span>
+            <input id="popupReminder" v-model="popupReminder" type="checkbox" class="checkbox" name="popupReminder"><span>{{ $t('UIEventForm.label.popupReminder') }}</span>
           </label>
         </div>
       </div>


### PR DESCRIPTION
{{ $t('UIEventForm.label.popupReminder') }} instead of "Display a notification pop-up".